### PR TITLE
Add GitHub Actions workflow for Paketbox tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Paketbox Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run test suite
+        env:
+          PYTHONPATH: .
+        run: |
+          python3 --version
+          python3 tests/run_tests.py


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that sets up Python 3.12 and runs the Paketbox test suite on pushes to main and on pull requests

## Testing
- `PYTHONPATH=. python3 tests/run_tests.py` *(fails: existing failures in the baseline test suite)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3349e974832ea5b0e8c7499cd300)