### PR TITLE
Add MQTT and timer manager unit tests

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -10,8 +10,17 @@ import unittest
 import sys
 import os
 
+
+def _prepare_sys_path():
+    """Ensure the repository root is importable for test modules."""
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.dirname(tests_dir)
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+
 def main():
     """Run all paketbox tests"""
+    _prepare_sys_path()
     print("=" * 60)
     print("Paketbox Test Environment")
     print("=" * 60)

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -1,0 +1,126 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+import importlib
+
+mqtt_module = importlib.import_module('mqtt')
+
+
+class TestMQTT(unittest.TestCase):
+    def setUp(self):
+        self.original_topics = {
+            'MQTT_USER': mqtt_module.config.MQTT_USER,
+            'MQTT_PASS': mqtt_module.config.MQTT_PASS,
+            'MQTT_BROKER': mqtt_module.config.MQTT_BROKER,
+            'MQTT_PORT': mqtt_module.config.MQTT_PORT,
+            'MQTT_TOPIC_MESSAGE': mqtt_module.config.MQTT_TOPIC_MESSAGE,
+            'MQTT_TOPIC_PAKETZUSTELLER': mqtt_module.config.MQTT_TOPIC_PAKETZUSTELLER,
+            'MQTT_TOPIC_BRIEFKASTEN': mqtt_module.config.MQTT_TOPIC_BRIEFKASTEN,
+            'MQTT_TOPIC_BRIEFKASTEN_ENTLEEREN': mqtt_module.config.MQTT_TOPIC_BRIEFKASTEN_ENTLEEREN,
+            'MQTT_TOPIC_PAKETBOX_ENTLEEREN': mqtt_module.config.MQTT_TOPIC_PAKETBOX_ENTLEEREN,
+        }
+        mqtt_module.config.MQTT_USER = 'user'
+        mqtt_module.config.MQTT_PASS = 'pass'
+        mqtt_module.config.MQTT_BROKER = 'broker'
+        mqtt_module.config.MQTT_PORT = 1883
+        mqtt_module.config.MQTT_TOPIC_MESSAGE = 'topic/message'
+        mqtt_module.config.MQTT_TOPIC_PAKETZUSTELLER = 'topic/paket'
+        mqtt_module.config.MQTT_TOPIC_BRIEFKASTEN = 'topic/brief'
+        mqtt_module.config.MQTT_TOPIC_BRIEFKASTEN_ENTLEEREN = 'topic/brief_empty'
+        mqtt_module.config.MQTT_TOPIC_PAKETBOX_ENTLEEREN = 'topic/paket_empty'
+        self.original_client = mqtt_module._client
+        self.original_available = mqtt_module.MQTT_AVAILABLE
+        mqtt_module._client = None
+        mqtt_module.MQTT_AVAILABLE = True
+
+    def tearDown(self):
+        for key, value in self.original_topics.items():
+            setattr(mqtt_module.config, key, value)
+        mqtt_module._client = self.original_client
+        mqtt_module.MQTT_AVAILABLE = self.original_available
+
+    @patch('mqtt.mqtt', new_callable=MagicMock)
+    def test_start_mqtt_initializes_client(self, mock_mqtt_module):
+        mock_client = MagicMock()
+        mock_mqtt_module.Client.return_value = mock_client
+
+        result = mqtt_module.start_mqtt()
+
+        self.assertTrue(result)
+        self.assertIs(mqtt_module._client, mock_client)
+        mock_client.username_pw_set.assert_called_once_with('user', 'pass')
+        mock_client.connect.assert_called_once_with('broker', 1883, 60)
+        mock_client.loop_start.assert_called_once()
+        self.assertIs(mock_client.on_connect, mqtt_module.mqtt_connect)
+        self.assertIs(mock_client.on_disconnect, mqtt_module.mqtt_disconnect)
+        self.assertIs(mock_client.on_message, mqtt_module.mqtt_message)
+
+    def test_start_mqtt_returns_false_when_unavailable(self):
+        mqtt_module.MQTT_AVAILABLE = False
+
+        result = mqtt_module.start_mqtt()
+
+        self.assertFalse(result)
+        self.assertIsNone(mqtt_module._client)
+
+    def test_stop_mqtt_stops_loop_and_disconnects(self):
+        client = MagicMock()
+        mqtt_module._client = client
+
+        mqtt_module.stop_mqtt()
+
+        client.loop_stop.assert_called_once_with()
+        client.disconnect.assert_called_once_with()
+
+    @patch('mqtt.time.sleep')
+    def test_mqtt_disconnect_retries_with_backoff(self, mock_sleep):
+        client = MagicMock()
+        client.reconnect.side_effect = [Exception('fail1'), Exception('fail2'), None]
+
+        mqtt_module.mqtt_disconnect(client, None, 0)
+
+        self.assertEqual(client.reconnect.call_count, 3)
+        mock_sleep.assert_has_calls([call(5), call(10), call(20)])
+
+    @patch('mqtt.time.sleep')
+    def test_mqtt_disconnect_returns_immediately_when_unavailable(self, mock_sleep):
+        mqtt_module.MQTT_AVAILABLE = False
+        client = MagicMock()
+
+        mqtt_module.mqtt_disconnect(client, None, 0)
+
+        mock_sleep.assert_not_called()
+        client.reconnect.assert_not_called()
+
+    def test_publish_helpers_use_correct_topics(self):
+        client = MagicMock()
+        mqtt_module._client = client
+        publish_calls = [
+            (mqtt_module.publish_status, 'MQTT_TOPIC_MESSAGE', 'status'),
+            (mqtt_module.publish_paket_zusteller_event, 'MQTT_TOPIC_PAKETZUSTELLER', 'zusteller'),
+            (mqtt_module.publish_briefkasten_event, 'MQTT_TOPIC_BRIEFKASTEN', 'brief'),
+            (mqtt_module.publish_briefkasten_entleeren_event, 'MQTT_TOPIC_BRIEFKASTEN_ENTLEEREN', 'brief_empty'),
+            (mqtt_module.publish_paketbox_entleeren_event, 'MQTT_TOPIC_PAKETBOX_ENTLEEREN', 'paket_empty'),
+        ]
+
+        for func, topic_attr, payload in publish_calls:
+            with self.subTest(func=func.__name__):
+                client.publish.reset_mock()
+                result = func(payload)
+                self.assertTrue(result)
+                client.publish.assert_called_once_with(getattr(mqtt_module.config, topic_attr), payload)
+
+    def test_publish_status_handles_missing_client_and_unavailable(self):
+        mqtt_module._client = None
+        result_no_client = mqtt_module.publish_status('status')
+        self.assertFalse(result_no_client)
+
+        mqtt_module.MQTT_AVAILABLE = False
+        mqtt_module._client = MagicMock()
+        result_unavailable = mqtt_module.publish_status('status')
+        self.assertFalse(result_unavailable)
+        mqtt_module._client.publish.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_timer_manager.py
+++ b/tests/test_timer_manager.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import MagicMock
+
+from TimerManager import TimerManager
+
+
+class TestTimerManager(unittest.TestCase):
+    def setUp(self):
+        self.manager = TimerManager()
+
+    def _prepare_lock(self):
+        lock = MagicMock()
+        lock.__enter__.return_value = None
+        lock.__exit__.return_value = None
+        self.manager._lock = lock
+        return lock
+
+    def test_add_timer_replaces_existing_and_uses_lock(self):
+        existing_timer = MagicMock()
+        new_timer = MagicMock()
+        self.manager.active_timers['left_motor'] = existing_timer
+        lock = self._prepare_lock()
+
+        self.manager.add_timer('left_motor', new_timer)
+
+        existing_timer.cancel.assert_called_once_with()
+        self.assertIs(self.manager.active_timers['left_motor'], new_timer)
+        lock.__enter__.assert_called_once()
+        lock.__exit__.assert_called_once()
+
+    def test_add_timer_creates_new_entry(self):
+        new_timer = MagicMock()
+        lock = self._prepare_lock()
+
+        self.manager.add_timer('custom_timer', new_timer)
+
+        self.assertIn('custom_timer', self.manager.active_timers)
+        self.assertIs(self.manager.active_timers['custom_timer'], new_timer)
+        lock.__enter__.assert_called_once()
+
+    def test_cancel_timer_cancels_and_clears_reference(self):
+        timer = MagicMock()
+        self.manager.active_timers['right_motor'] = timer
+        lock = self._prepare_lock()
+
+        self.manager.cancel_timer('right_motor')
+
+        timer.cancel.assert_called_once_with()
+        self.assertIsNone(self.manager.active_timers['right_motor'])
+        lock.__enter__.assert_called_once()
+
+    def test_cancel_all_timers_cancels_everything_and_resets_dict(self):
+        timers = {
+            'left_motor': MagicMock(),
+            'right_motor': None,
+            'left_check': MagicMock(),
+        }
+        self.manager.active_timers.update(timers)
+        lock = self._prepare_lock()
+
+        self.manager.cancel_all_timers()
+
+        timers['left_motor'].cancel.assert_called_once_with()
+        timers['left_check'].cancel.assert_called_once_with()
+        self.assertTrue(all(value is None for value in self.manager.active_timers.values()))
+        lock.__enter__.assert_called_once()
+
+    def test_clear_timer_removes_reference(self):
+        self.manager.active_timers['left_motor'] = MagicMock()
+        lock = self._prepare_lock()
+
+        self.manager.clear_timer('left_motor')
+
+        self.assertIsNone(self.manager.active_timers['left_motor'])
+        lock.__enter__.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a TimerManager unit test module that exercises timer registration, cancellation, clearing, and lock usage
- add an MQTT unit test module that mocks the paho client and verifies start/stop behavior, reconnect backoff, and all publish helpers
- update the custom test runner to add the repository root to `sys.path` so that the new tests are discoverable and import project modules correctly

## Testing
- python tests/run_tests.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a3987b850832ea3431cb0801ba51a)